### PR TITLE
add sumologic dashboard compat metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Sumologic compat metrics enabled with --sumologic-compat flag
 
 ## [0.0.1] - 2000-01-01
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Flags:
   -r, --max-rate-interval int        Maximum number of seconds since last measurement that triggers a rate calculation. 0 for no maximum. (default 60)
   -f, --state-file string            State file used for rate calculation. If empty no rate is calculated.
   -s, --sum                          Add additional measurement per metric w/ "interface=all" tag
-
+      --sumologic-compat             Add Sumo Logic compatible metrics with w/ "host_net" family
 
 Use "network-interface-checks [command] --help" for more information about a command.
 ```
@@ -84,6 +84,7 @@ Use "network-interface-checks [command] --help" for more information about a com
 | --exclude-interfaces | NETWORK_INTERFACE_CHECKS_EXCLUDE_INTERFACES |
 | --max-rate-interval  | NETWORK_INTERFACE_CHECKS_MAX_RATE_INTERVAL  |
 | --state-file         | NETWORK_INTERFACE_CHECKS_STATE_FILE         |
+| --sumologic-compat   | NETWORK_INTERFACE_CHECKS_SUMOLOGIC_COMPAT   |
 
 ## Configuration
 ### Asset registration

--- a/main.go
+++ b/main.go
@@ -3,19 +3,21 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"log"
+	"os"
+	"strings"
+
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	v2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-plugin-sdk/sensu"
-	"log"
-	"os"
-	"strings"
 )
 
 // Config represents the check plugin config.
 type Config struct {
 	sensu.PluginConfig
 	Sum                    bool
+	SumoLogicCompat        bool
 	IncludeInterfaces      []string
 	ExcludeInterfaces      []string
 	StateFile              string
@@ -37,6 +39,14 @@ var (
 
 	options = []*sensu.PluginConfigOption{
 		{
+			Path:      "sum",
+			Env:       "NETWORK_INTERFACE_CHECKS_SUMOLOGIC_COMPAT",
+			Argument:  "sumologic-compat",
+			Shorthand: "",
+			Default:   false,
+			Usage:     "Add Sumo Logic compatible metrics with w/ \"host_net\" family",
+			Value:     &plugin.SumoLogicCompat,
+		}, {
 			Path:      "sum",
 			Env:       "NETWORK_INTERFACE_CHECKS_SUM",
 			Argument:  "sum",
@@ -121,7 +131,7 @@ func checkArgs(_ *v2.Event) (int, error) {
 }
 
 func collectMetrics() ([]*dto.MetricFamily, error) {
-	collector, err := NewCollector(plugin.IncludeInterfaces, plugin.ExcludeInterfaces, plugin.Sum, plugin.StateFile,
+	collector, err := NewCollector(plugin.IncludeInterfaces, plugin.ExcludeInterfaces, plugin.Sum, plugin.SumoLogicCompat, plugin.StateFile,
 		plugin.MaxRateIntervalSeconds)
 	if err != nil {
 		return nil, err

--- a/network.go
+++ b/network.go
@@ -29,8 +29,10 @@ var (
 		"drop_in":           "incoming packets dropped",
 		"drop_in_rate":      "incoming packets dropped per second",
 		"mtu":               "interface MTU configuration",
+		"host_net":          "SumoLogic Compatibility",
 	}
 	interfaceLabel = "interface"
+	fieldLabel     = "field"
 )
 
 type MetricCollector struct {
@@ -85,6 +87,10 @@ func (c *MetricCollector) Collect(netStatsGetter func(*selector) (NetStats, erro
 func (c *MetricCollector) generatePromMetrics(stats NetStats, metricState *metric.CounterMetricState) []*dto.MetricFamily {
 	families := make([]*dto.MetricFamily, 0)
 	nowMS := time.Now().UnixMilli()
+	metricType := "host_net"
+	help := metricHelp[metricType]
+	sumo_family := newMetricFamily(metricType, help, dto.MetricType_COUNTER)
+	families = append(families, sumo_family)
 
 	for metricType, typeStats := range stats {
 		help := metricHelp[metricType]
@@ -107,6 +113,7 @@ func (c *MetricCollector) generatePromMetrics(stats NetStats, metricState *metri
 
 		for netIF, ifValue := range typeStats {
 			counter := newCounterMetric(family, netIF, ifValue, nowMS)
+			_ = newSumoCounterMetric(sumo_family, metricType, netIF, ifValue, nowMS)
 			found, prevValue, prevTimestampMS := metricState.GetMetric(family, counter)
 			metricState.AddMetric(family, counter)
 			total += ifValue
@@ -148,7 +155,25 @@ func newMetricFamily(name, help string, metricType dto.MetricType) *dto.MetricFa
 
 func newCounterMetric(family *dto.MetricFamily, ifName string, value float64, timestampMS int64) *dto.Metric {
 	counter := &dto.Metric{
-		Label: []*dto.LabelPair{{Name: &interfaceLabel, Value: &ifName}},
+		Label: []*dto.LabelPair{
+			{Name: &interfaceLabel, Value: &ifName},
+			//{Name: &fieldLabel, Value: &fieldName},
+		},
+		Counter: &dto.Counter{
+			Value: &value,
+		},
+		TimestampMs: &timestampMS,
+	}
+	family.Metric = append(family.Metric, counter)
+
+	return counter
+}
+func newSumoCounterMetric(family *dto.MetricFamily, fieldName string, ifName string, value float64, timestampMS int64) *dto.Metric {
+	counter := &dto.Metric{
+		Label: []*dto.LabelPair{
+			{Name: &interfaceLabel, Value: &ifName},
+			{Name: &fieldLabel, Value: &fieldName},
+		},
 		Counter: &dto.Counter{
 			Value: &value,
 		},

--- a/network_test.go
+++ b/network_test.go
@@ -37,7 +37,7 @@ func GetNetStatsMock2(_ *selector) (NetStats, error) {
 func TestMetricCollector_CollectWithSum(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), uuid.New().String()+".json")
 	// Sum, no rates
-	collector, err := NewCollector([]string{}, []string{}, true, tmpFile, 60)
+	collector, err := NewCollector([]string{}, []string{}, true, true, tmpFile, 60)
 	assert.NoError(t, err)
 	families, err := collector.Collect(GetNetStatsMock1)
 	assert.NoError(t, err)
@@ -60,7 +60,7 @@ func TestMetricCollector_CollectWithSum(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Second run there will be sum and rates
-	collector, err = NewCollector([]string{}, []string{}, true, tmpFile, 60)
+	collector, err = NewCollector([]string{}, []string{}, true, true, tmpFile, 60)
 	assert.NoError(t, err)
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)
@@ -87,7 +87,7 @@ func TestMetricCollector_CollectNoSum(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), uuid.New().String()+".json")
 
 	// Sum, no rates
-	collector, err := NewCollector([]string{}, []string{}, false, tmpFile, 60)
+	collector, err := NewCollector([]string{}, []string{}, false, true, tmpFile, 60)
 	assert.NoError(t, err)
 	families, err := collector.Collect(GetNetStatsMock1)
 	assert.NoError(t, err)
@@ -110,7 +110,7 @@ func TestMetricCollector_CollectNoSum(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Second run there will be sum and rates
-	collector, err = NewCollector([]string{}, []string{}, false, tmpFile, 60)
+	collector, err = NewCollector([]string{}, []string{}, false, true, tmpFile, 60)
 	assert.NoError(t, err)
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)
@@ -136,7 +136,7 @@ func TestCollect_NoFile(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), uuid.New().String()+".json")
 
 	// No rates since it's first time writing to file
-	collector, err := NewCollector([]string{}, []string{}, false, tmpFile, 60)
+	collector, err := NewCollector([]string{}, []string{}, false, true, tmpFile, 60)
 	assert.NoError(t, err)
 	families, err := collector.Collect(GetNetStatsMock1)
 	assert.NoError(t, err)
@@ -156,7 +156,7 @@ func TestCollect_NoFile(t *testing.T) {
 	}
 
 	// Second run with no file there will be no rates
-	collector, err = NewCollector([]string{}, []string{}, false, "", 60)
+	collector, err = NewCollector([]string{}, []string{}, false, true, "", 60)
 	assert.NoError(t, err)
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)
@@ -173,7 +173,7 @@ func TestCollect_MaxRateInterval(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), uuid.New().String()+".json")
 
 	// First run to generate a state file
-	collector, err := NewCollector([]string{}, []string{}, false, tmpFile, 3)
+	collector, err := NewCollector([]string{}, []string{}, false, true, tmpFile, 3)
 	assert.NoError(t, err)
 	families, err := collector.Collect(GetNetStatsMock1)
 	assert.NoError(t, err)
@@ -194,7 +194,7 @@ func TestCollect_MaxRateInterval(t *testing.T) {
 
 	// Second run with a small delay, should produce rate metrics
 	time.Sleep(time.Second * 1)
-	collector, err = NewCollector([]string{}, []string{}, false, tmpFile, 3)
+	collector, err = NewCollector([]string{}, []string{}, false, true, tmpFile, 3)
 	assert.NoError(t, err)
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)
@@ -208,7 +208,7 @@ func TestCollect_MaxRateInterval(t *testing.T) {
 
 	// Third run with a long delay, no rates should be produced
 	time.Sleep(time.Second * 3)
-	collector, err = NewCollector([]string{}, []string{}, false, tmpFile, 1)
+	collector, err = NewCollector([]string{}, []string{}, false, true, tmpFile, 1)
 	assert.NoError(t, err)
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)
@@ -222,7 +222,7 @@ func TestCollect_MaxRateInterval(t *testing.T) {
 
 	// Fourth run with a long delay and 0 interval, should be produced
 	time.Sleep(time.Second * 3)
-	collector, err = NewCollector([]string{}, []string{}, false, tmpFile, 0)
+	collector, err = NewCollector([]string{}, []string{}, false, true, tmpFile, 0)
 	assert.NoError(t, err)
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)

--- a/network_test.go
+++ b/network_test.go
@@ -42,13 +42,18 @@ func TestMetricCollector_CollectWithSum(t *testing.T) {
 	families, err := collector.Collect(GetNetStatsMock1)
 	assert.NoError(t, err)
 	assert.NotNil(t, families)
-	assert.Len(t, families, 2)
+	assert.Len(t, families, 3)
 	familyMap := familiesByName(families)
 	assert.Contains(t, familyMap, "bytes_sent")
 	assert.Contains(t, familyMap, "err_in")
 	for _, family := range families {
-		assert.Len(t, family.Metric, 3)
-		assert.True(t, hasSumMetric(family))
+		if family.GetName() == "host_net" {
+			assert.Len(t, family.Metric, 4)
+			assert.False(t, hasSumMetric(family))
+		} else {
+			assert.Len(t, family.Metric, 3)
+			assert.True(t, hasSumMetric(family))
+		}
 	}
 
 	// small sleep to ensure second call to Collect has different timestamp
@@ -60,15 +65,21 @@ func TestMetricCollector_CollectWithSum(t *testing.T) {
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)
 	assert.NotNil(t, families)
-	assert.Len(t, families, 4)
+	assert.Len(t, families, 5)
 	familyMap = familiesByName(families)
 	assert.Contains(t, familyMap, "bytes_sent")
 	assert.Contains(t, familyMap, "bytes_sent_rate")
 	assert.Contains(t, familyMap, "err_in")
 	assert.Contains(t, familyMap, "err_in_rate")
 	for _, family := range families {
-		assert.Len(t, family.Metric, 3)
-		assert.True(t, hasSumMetric(family))
+		if family.GetName() == "host_net" {
+			assert.Len(t, family.Metric, 4)
+			assert.False(t, hasSumMetric(family))
+			continue
+		} else {
+			assert.Len(t, family.Metric, 3)
+			assert.True(t, hasSumMetric(family))
+		}
 	}
 }
 
@@ -81,13 +92,18 @@ func TestMetricCollector_CollectNoSum(t *testing.T) {
 	families, err := collector.Collect(GetNetStatsMock1)
 	assert.NoError(t, err)
 	assert.NotNil(t, families)
-	assert.Len(t, families, 2)
+	assert.Len(t, families, 3)
 	familyMap := familiesByName(families)
 	assert.Contains(t, familyMap, "bytes_sent")
 	assert.Contains(t, familyMap, "err_in")
 	for _, family := range families {
-		assert.Len(t, family.Metric, 2)
-		assert.False(t, hasSumMetric(family))
+		if family.GetName() == "host_net" {
+			assert.Len(t, family.Metric, 4)
+			assert.False(t, hasSumMetric(family))
+		} else {
+			assert.Len(t, family.Metric, 2)
+			assert.False(t, hasSumMetric(family))
+		}
 	}
 
 	// small sleep to ensure second call to Collect has different timestamp
@@ -99,15 +115,20 @@ func TestMetricCollector_CollectNoSum(t *testing.T) {
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)
 	assert.NotNil(t, families)
-	assert.Len(t, families, 4)
+	assert.Len(t, families, 5)
 	familyMap = familiesByName(families)
 	assert.Contains(t, familyMap, "bytes_sent")
 	assert.Contains(t, familyMap, "bytes_sent_rate")
 	assert.Contains(t, familyMap, "err_in")
 	assert.Contains(t, familyMap, "err_in_rate")
 	for _, family := range families {
-		assert.Len(t, family.Metric, 2)
-		assert.False(t, hasSumMetric(family))
+		if family.GetName() == "host_net" {
+			assert.Len(t, family.Metric, 4)
+			assert.False(t, hasSumMetric(family))
+		} else {
+			assert.Len(t, family.Metric, 2)
+			assert.False(t, hasSumMetric(family))
+		}
 	}
 }
 
@@ -120,13 +141,18 @@ func TestCollect_NoFile(t *testing.T) {
 	families, err := collector.Collect(GetNetStatsMock1)
 	assert.NoError(t, err)
 	assert.NotNil(t, families)
-	assert.Len(t, families, 2)
+	assert.Len(t, families, 3)
 	familyMap := familiesByName(families)
 	assert.Contains(t, familyMap, "bytes_sent")
 	assert.Contains(t, familyMap, "err_in")
 	for _, family := range families {
-		assert.Len(t, family.Metric, 2)
-		assert.False(t, hasSumMetric(family))
+		if family.GetName() == "host_net" {
+			assert.Len(t, family.Metric, 4)
+			assert.False(t, hasSumMetric(family))
+		} else {
+			assert.Len(t, family.Metric, 2)
+			assert.False(t, hasSumMetric(family))
+		}
 	}
 
 	// Second run with no file there will be no rates
@@ -135,7 +161,7 @@ func TestCollect_NoFile(t *testing.T) {
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)
 	assert.NotNil(t, families)
-	assert.Len(t, families, 2)
+	assert.Len(t, families, 3)
 	familyMap = familiesByName(families)
 	assert.Contains(t, familyMap, "bytes_sent")
 	assert.NotContains(t, familyMap, "bytes_sent_rate")
@@ -152,13 +178,18 @@ func TestCollect_MaxRateInterval(t *testing.T) {
 	families, err := collector.Collect(GetNetStatsMock1)
 	assert.NoError(t, err)
 	assert.NotNil(t, families)
-	assert.Len(t, families, 2)
+	assert.Len(t, families, 3)
 	familyMap := familiesByName(families)
 	assert.Contains(t, familyMap, "bytes_sent")
 	assert.Contains(t, familyMap, "err_in")
 	for _, family := range families {
-		assert.Len(t, family.Metric, 2)
-		assert.False(t, hasSumMetric(family))
+		if family.GetName() == "host_net" {
+			assert.Len(t, family.Metric, 4)
+			assert.False(t, hasSumMetric(family))
+		} else {
+			assert.Len(t, family.Metric, 2)
+			assert.False(t, hasSumMetric(family))
+		}
 	}
 
 	// Second run with a small delay, should produce rate metrics
@@ -168,7 +199,7 @@ func TestCollect_MaxRateInterval(t *testing.T) {
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)
 	assert.NotNil(t, families)
-	assert.Len(t, families, 4)
+	assert.Len(t, families, 5)
 	familyMap = familiesByName(families)
 	assert.Contains(t, familyMap, "bytes_sent")
 	assert.Contains(t, familyMap, "bytes_sent_rate")
@@ -182,7 +213,7 @@ func TestCollect_MaxRateInterval(t *testing.T) {
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)
 	assert.NotNil(t, families)
-	assert.Len(t, families, 2)
+	assert.Len(t, families, 3)
 	familyMap = familiesByName(families)
 	assert.Contains(t, familyMap, "bytes_sent")
 	assert.NotContains(t, familyMap, "bytes_sent_rate")
@@ -196,7 +227,7 @@ func TestCollect_MaxRateInterval(t *testing.T) {
 	families, err = collector.Collect(GetNetStatsMock2)
 	assert.NoError(t, err)
 	assert.NotNil(t, families)
-	assert.Len(t, families, 4)
+	assert.Len(t, families, 5)
 	familyMap = familiesByName(families)
 	assert.Contains(t, familyMap, "bytes_sent")
 	assert.Contains(t, familyMap, "bytes_sent_rate")


### PR DESCRIPTION
This adds a new `host_net` metrics family for network metric counters that should match SumoLogic dashboard expectation.
metric name is encoded as a label named `field` 
Closing #3 